### PR TITLE
턴 날짜 저장, 보유 주식 불러오기

### DIFF
--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsController.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsController.java
@@ -1,0 +1,24 @@
+package team.shdsesc.stocksimul.holdings;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/holdings")
+@RequiredArgsConstructor
+public class HoldingsController {
+    private final HoldingsService holdingsService;
+
+    @GetMapping("/stocks/{usersProfileId}")
+    ResponseEntity<List<HoldingsResponseDTO>> getHoldingsStockList(@PathVariable Long usersProfileId){
+        return ResponseEntity
+                .ok()
+                .body(holdingsService.getHoldingsList(usersProfileId));
+    }
+}

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsEntity.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsEntity.java
@@ -1,0 +1,43 @@
+package team.shdsesc.stocksimul.holdings;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+import team.shdsesc.stocksimul.market.entity.Stock;
+import team.shdsesc.stocksimul.userprofile.UserProfileEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "holdings")
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HoldingsEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "holdings_id")
+    private Long holdingsId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_profile_id", nullable = false)
+    private UserProfileEntity userProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    @Column(name = "quantity")
+    private Long quantity;
+
+    @Column(name = "price")
+    private Double price;
+
+    @LastModifiedDate
+    @Column(name = "mod_date")
+    private LocalDateTime modDate;
+}

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsRepository.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsRepository.java
@@ -1,0 +1,8 @@
+package team.shdsesc.stocksimul.holdings;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HoldingsRepository extends JpaRepository<HoldingsEntity,Long>, HoldingsRepositoryCustom {
+}

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsRepositoryCustom.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsRepositoryCustom.java
@@ -1,0 +1,11 @@
+package team.shdsesc.stocksimul.holdings;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HoldingsRepositoryCustom{
+    Optional<List<HoldingsEntity>> getHoldingsList(Long usersProfileId);
+}

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsRepositoryCustomImpl.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package team.shdsesc.stocksimul.holdings;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class HoldingsRepositoryCustomImpl implements HoldingsRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<List<HoldingsEntity>> getHoldingsList(Long usersProfileId) {
+
+        QHoldingsEntity holdingsEntity = QHoldingsEntity.holdingsEntity;
+
+        List<HoldingsEntity> result =  queryFactory
+                .selectFrom(holdingsEntity)
+                .leftJoin(holdingsEntity.stock)
+                .fetchJoin()
+                .where(holdingsEntity.userProfile.usersProfileId.eq(usersProfileId))
+                .fetch();
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsResponseDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsResponseDTO.java
@@ -1,0 +1,19 @@
+package team.shdsesc.stocksimul.holdings;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HoldingsResponseDTO {
+    private String ticker;
+    private String name;
+    private Double price;
+    private Double change;
+    private Double changeAmount;
+    private String logo;
+}

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsService.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsService.java
@@ -1,0 +1,38 @@
+package team.shdsesc.stocksimul.holdings;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.shdsesc.stocksimul.market.entity.Stock;
+import team.shdsesc.stocksimul.userprofile.UserProfileRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HoldingsService {
+    private final HoldingsRepository holdingsRepository;
+    private static final String STOCK_IMG_LINK = "https://financialmodelingprep.com/image-stock/";
+    private static final String STOCK_IMG_EXTENSION = ".png";
+
+
+    HoldingsResponseDTO toHoldingsResponseDTOS(HoldingsEntity holdingsEntity) {
+        return HoldingsResponseDTO.builder()
+                .ticker(holdingsEntity.getStock().getTicker())
+                .name(holdingsEntity.getStock().getName())
+                .price(holdingsEntity.getPrice())
+                .change(-0.2)
+                .changeAmount(-0.48)
+                .logo(STOCK_IMG_LINK + holdingsEntity.getStock().getTicker() + STOCK_IMG_EXTENSION)
+                .build();
+
+    }
+
+    List<HoldingsResponseDTO> getHoldingsList(Long usersProfileId) {
+        List<HoldingsEntity> holdingsEntityList = holdingsRepository.getHoldingsList(usersProfileId).orElseThrow(() -> new RuntimeException("Holdings not found"));
+        return holdingsEntityList
+                .stream()
+                .map(this::toHoldingsResponseDTOS)
+                .toList();
+    }
+
+}

--- a/src/main/java/team/shdsesc/stocksimul/market/entity/Stock.java
+++ b/src/main/java/team/shdsesc/stocksimul/market/entity/Stock.java
@@ -4,10 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -15,6 +12,7 @@ import java.time.LocalDate;
 @Table(name = "stock")
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Stock {

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UpdateUserProfileProcessDateDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UpdateUserProfileProcessDateDTO.java
@@ -1,0 +1,15 @@
+package team.shdsesc.stocksimul.userprofile;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateUserProfileProcessDateDTO {
+    private Long userProfileId;
+    private String processDate;
+}

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileController.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileController.java
@@ -59,5 +59,14 @@ public class UserProfileController {
                 .ok()
                 .build();
     }
+
+    @PostMapping("/update/process-date")
+    @Operation(summary = "진행 날짜 업데이트", description = "턴 종료 시 진행 날짜를 업데이트 합니다.")
+    public ResponseEntity<?> updateProcessDate(@RequestBody UpdateUserProfileProcessDateDTO userProfileProcessDateDTO) {
+        userProfileService.updateProcessDate(userProfileProcessDateDTO.getUserProfileId(), userProfileProcessDateDTO.getProcessDate());
+        return ResponseEntity
+                .ok()
+                .build();
+    }
 }
 

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileDTO.java
@@ -1,10 +1,12 @@
 package team.shdsesc.stocksimul.userprofile;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
@@ -21,5 +23,6 @@ public class UserProfileDTO {
     @Builder.Default
     private String name ="";
     private Integer state;
-    private LocalDateTime processDate;
+
+    private LocalDate processDate;
 }

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileRepositoryCustom.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileRepositoryCustom.java
@@ -1,8 +1,10 @@
 package team.shdsesc.stocksimul.userprofile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface UserProfileRepositoryCustom {
     Optional<List<UserProfileEntity>> findUserByUserEmail(String email);
+    void updateUserProfileByProcessDate(LocalDateTime date, Long userProfileId);
 }

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileRepositoryCustomImpl.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package team.shdsesc.stocksimul.userprofile;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,5 +22,15 @@ public class UserProfileRepositoryCustomImpl implements UserProfileRepositoryCus
                 .fetch();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public void updateUserProfileByProcessDate(LocalDateTime date, Long userProfileId){
+        QUserProfileEntity userProfile = QUserProfileEntity.userProfileEntity;
+
+        queryFactory.update(userProfile)
+                .set(userProfile.processDate, date)
+                .where(userProfile.usersProfileId.eq(userProfileId))
+                .execute();
     }
 }

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileService.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileService.java
@@ -7,7 +7,10 @@ import org.springframework.stereotype.Service;
 import team.shdsesc.stocksimul.user.UserEntity;
 import team.shdsesc.stocksimul.user.UserRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -48,6 +51,15 @@ public class UserProfileService {
         userRepository.updateCurrentProfileUser(user.getUsersId(), updateUserProfileDTO.getUserProfileId());
     }
 
+    @Transactional
+    public void updateProcessDate(Long id, String date){
+        // 1) 문자열을 LocalDate 로 파싱
+        LocalDate localDate = LocalDate.parse(date);
+        // 2) 원하는 시각(예: 자정) 붙여서 LocalDateTime 으로 변환
+        LocalDateTime processDate = localDate.atStartOfDay();
+        userProfileRepository.updateUserProfileByProcessDate(processDate, id);
+    }
+
     public UserProfileDTO getCurrentUserProfile(Long pid){
         UserProfileEntity userProfileEntity = userProfileRepository.findById(pid).orElseThrow(() -> new RuntimeException("UserProfile not found"));
         return toUserProfileDTO(userProfileEntity);
@@ -71,7 +83,7 @@ public class UserProfileService {
                 .cashBalance(entity.getCashBalance())
                 .nickname(entity.getNickname())
                 .name(entity.getTimeLine().getName())
-                .processDate(entity.getProcessDate())
+                .processDate(entity.getProcessDate().toLocalDate())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #10, #14

## 📝작업 내용

> 턴 종료 시 날짜 업데이트
> 유저 프로필 생성 시 생성 날짜로 업데이트 (한국 표준 시)
> 보유 종목 리스트로 불러오는 로직 추가

### 스크린샷 (선택)

### 보유 주식
<img width="562" height="860" alt="image" src="https://github.com/user-attachments/assets/84889872-1f40-4709-b2f1-6e45d585c416" />

### 날짜 업데이트
<img width="354" height="120" alt="image" src="https://github.com/user-attachments/assets/420354dc-8892-450c-9be4-6e7be44b61b2" />

<img width="520" height="57" alt="image" src="https://github.com/user-attachments/assets/9a2907e4-5613-4478-8f48-0d2f3f050525" />

### 이후 포트폴리오를 보여줄 팝업
<img width="671" height="813" alt="image" src="https://github.com/user-attachments/assets/ad32d0f8-c30b-4a6f-87e8-255eb1a2f05c" />


## 💬리뷰 요구사항(선택)

> 