### PR TITLE
FastAPI 연동 (/predict)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/team/shdsesc/stocksimul/agent/AgentController.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/AgentController.java
@@ -1,0 +1,31 @@
+package team.shdsesc.stocksimul.agent;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/dev/agent")
+@Log4j2
+public class AgentController {
+
+    private final AgentService agentService;
+
+    @PostMapping("/predict")
+    public Mono<ResponseEntity<PredictResponseDTO>> predict(@RequestBody PredictRequestDTO requestDTO) {
+        log.info("Predict request: {}", requestDTO);
+
+        return agentService.predict(requestDTO)
+                .map(response -> {
+                    log.info("Predict response: {}", response);
+                    return ResponseEntity.ok(response);
+                });
+    }
+
+}

--- a/src/main/java/team/shdsesc/stocksimul/agent/AgentService.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/AgentService.java
@@ -1,0 +1,36 @@
+package team.shdsesc.stocksimul.agent;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class AgentService {
+
+    @Value("${fastApi.url}")
+    private String fastApiUrl;
+
+    public Mono<PredictResponseDTO> predict(PredictRequestDTO requestDTO) {
+        WebClient webClient = WebClient.builder()
+                .baseUrl(fastApiUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        return webClient.post()
+                .uri("/predict")
+                .bodyValue(requestDTO)
+                .retrieve()
+                .bodyToMono(PredictResponseDTO.class)
+                .onErrorResume(throwable -> {
+//                    return Mono.just(new PredictResponseDTO());
+                    return Mono.error(throwable);
+                });
+
+    }
+
+}

--- a/src/main/java/team/shdsesc/stocksimul/agent/PredictRequestDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/PredictRequestDTO.java
@@ -1,0 +1,29 @@
+package team.shdsesc.stocksimul.agent;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@ToString
+public class PredictRequestDTO {
+
+    @JsonProperty("ticker")
+    String ticker;
+
+    @JsonProperty("today")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    LocalDate baseDate;
+
+    @JsonProperty("train_days")
+    int trainDays;
+
+    @JsonProperty("predict_steps")
+    int predictDays;
+
+}

--- a/src/main/java/team/shdsesc/stocksimul/agent/PredictResponseDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/PredictResponseDTO.java
@@ -1,0 +1,34 @@
+package team.shdsesc.stocksimul.agent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class PredictResponseDTO {
+
+    @JsonProperty("ticker")
+    private String ticker;
+
+    @JsonProperty("base_date")
+    private LocalDate baseDate;
+
+    @JsonProperty("last_price")
+    private Double lastPrice;
+
+    @JsonProperty("train_data_count")
+    private int trainDataCount;
+
+    @JsonProperty("feature_count")
+    private int featureCount;
+
+    @JsonProperty("predicted")
+    private List<PredictResultDTO> results;
+}

--- a/src/main/java/team/shdsesc/stocksimul/agent/PredictResultDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/PredictResultDTO.java
@@ -1,0 +1,21 @@
+package team.shdsesc.stocksimul.agent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class PredictResultDTO {
+
+    @JsonProperty("day")
+    private int day;
+
+    @JsonProperty("return_rate")
+    private double returnRate;
+
+    @JsonProperty("price")
+    private double predictPrice;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11 의 연관 이슈

## 📝작업 내용

> spring boot 백엔드의 post /predict api를 호출하면 FastAPI로 비동기 요청을 보내고 응답을 받아오게 구현.
받아온 데이터를 기반으로 차트 혹은 표로 출력할 것을 요청

### 스크린샷 (선택)
<img width="431" height="407" alt="image" src="https://github.com/user-attachments/assets/d5f1731d-b9a4-4eff-a016-b5170ecb351a" />
<img width="544" height="488" alt="image" src="https://github.com/user-attachments/assets/bbb21bdf-eef9-47bd-819a-d34e01d430c3" />


## 💬리뷰 요구사항(선택)

> 