### PR TITLE
관심 종목 / 실시간, 과거 타임라인 데이터 구분 기능 추가 BE

### DIFF
--- a/src/main/java/team/shdsesc/stocksimul/auth/filter/TokenCheckFilter.java
+++ b/src/main/java/team/shdsesc/stocksimul/auth/filter/TokenCheckFilter.java
@@ -47,12 +47,17 @@ public class TokenCheckFilter extends OncePerRequestFilter {
         // test, api만 인증 토큰 필터 거침
         // 그 외에는 matcher에 적용하지 않은 경우 403
         // 🔹 토큰 검증에서 완전히 제외할 경로
-        log.info("path: " + path);
-        if (path.startsWith("/auth") || path.startsWith("/api/user/register")
-                || path.startsWith("/dev")
-                // favicon은 열어둬야 하나 말아야 하나..
-                || path.startsWith("/favicon.ico")
-                ) {
+        if (path.startsWith("/auth") || 
+            path.startsWith("/api/user/register") ||
+            path.startsWith("/user/register") ||
+            path.startsWith("/api/db/") ||
+            path.startsWith("/api/api/") ||
+            path.startsWith("/api/market/") ||
+            path.startsWith("/api/news/") ||
+            path.startsWith("/api/stock/") ||
+            path.startsWith("/api/tickers") ||
+            path.startsWith("/api/candles") ||
+            path.startsWith("/api/watchlist")) {
             filterChain.doFilter(request, response);
             return; // 여기서 바로 빠져나감 → 토큰 체크 안 함
         }

--- a/src/main/java/team/shdsesc/stocksimul/config/SecurityConfig.java
+++ b/src/main/java/team/shdsesc/stocksimul/config/SecurityConfig.java
@@ -61,10 +61,14 @@ public class SecurityConfig {
                 ).permitAll()                // .requestMatchers("/boards/register").hasAnyRole("BASIC","MANAGER","ADMIN")
                 .requestMatchers("/api/user/register").permitAll()
                 // 그 외 /api/user/** 는 인증 필요
+                .requestMatchers("/api/user/**").authenticated()
+                // 나머지 요청 처리
+                .anyRequest().permitAll()
                         .requestMatchers("/api/user/register").permitAll()
                         .requestMatchers("/api/db/**").permitAll()
                         .requestMatchers("/api/market/**").permitAll()
                         .requestMatchers("/api/news/**").permitAll()
+                        .requestMatchers("/api/watchlist/**").permitAll()
                         // 그 외 /api/user/** 는 인증 필요
                         .requestMatchers("/api/user/**").authenticated()
                         // 나머지 요청 처리

--- a/src/main/java/team/shdsesc/stocksimul/config/SecurityConfig.java
+++ b/src/main/java/team/shdsesc/stocksimul/config/SecurityConfig.java
@@ -58,21 +58,17 @@ public class SecurityConfig {
                         "/webjars/**",
                         "/configuration/ui",
                         "/configuration/security"
-                ).permitAll()                // .requestMatchers("/boards/register").hasAnyRole("BASIC","MANAGER","ADMIN")
+                ).permitAll()
+                .requestMatchers(
+                        "/api/db/**",
+                        "/api/market/**",
+                        "/api/news/**",
+                        "/api/watchlist/**"
+                ).permitAll()
                 .requestMatchers("/api/user/register").permitAll()
-                // 그 외 /api/user/** 는 인증 필요
+                .requestMatchers("/auth").permitAll()
                 .requestMatchers("/api/user/**").authenticated()
-                // 나머지 요청 처리
                 .anyRequest().permitAll()
-                        .requestMatchers("/api/user/register").permitAll()
-                        .requestMatchers("/api/db/**").permitAll()
-                        .requestMatchers("/api/market/**").permitAll()
-                        .requestMatchers("/api/news/**").permitAll()
-                        .requestMatchers("/api/watchlist/**").permitAll()
-                        // 그 외 /api/user/** 는 인증 필요
-                        .requestMatchers("/api/user/**").authenticated()
-                        // 나머지 요청 처리
-                        .anyRequest().permitAll()
         );
 
         // CORS 설정

--- a/src/main/java/team/shdsesc/stocksimul/market/controller/DbCandleController.java
+++ b/src/main/java/team/shdsesc/stocksimul/market/controller/DbCandleController.java
@@ -12,6 +12,7 @@ import team.shdsesc.stocksimul.market.dto.TickersResponse;
 import team.shdsesc.stocksimul.market.dto.SymbolsResponse;
 import team.shdsesc.stocksimul.market.service.DbMarketService;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 @RestController
@@ -34,16 +35,17 @@ public class DbCandleController {
             @RequestParam(value = "days", required = false) Integer days
     ) {
         CandleResponse body = dbMarketService.getCandles(tickerParam, symbolParam, from, to, days);
-        return ResponseEntity.ok(Map.of(
-                "s", body.getStatus(),
-                "t", body.getTimestamps(),
-                "d", body.getDates(),
-                "o", body.getOpens(),
-                "h", body.getHighs(),
-                "l", body.getLows(),
-                "c", body.getCloses(),
-                "v", body.getVolumes()
-        ));
+        java.util.Map<String, Object> resp = new java.util.HashMap<>();
+        // 풀네임 키만 제공
+        resp.put("status", body.getStatus());
+        resp.put("timestamps", body.getTimestamps());
+        resp.put("dates", body.getDates());
+        resp.put("opens", body.getOpens());
+        resp.put("highs", body.getHighs());
+        resp.put("lows", body.getLows());
+        resp.put("closes", body.getCloses());
+        resp.put("volumes", body.getVolumes());
+        return ResponseEntity.ok(resp);
     }
 
     @GetMapping("/last-range")
@@ -52,22 +54,56 @@ public class DbCandleController {
             @RequestParam(value = "days", required = false) Integer days
     ) {
         RangeResponse r = dbMarketService.getLastRange(ticker, days);
-        if (!"ok".equals(r.getStatus())) {
-            return ResponseEntity.ok(Map.of("s", "no_data"));
+        java.util.Map<String, Object> resp = new java.util.HashMap<>();
+        String status = r.getStatus();
+        resp.put("status", status);
+        if (!"ok".equals(status)) {
+            return ResponseEntity.ok(resp);
         }
-        return ResponseEntity.ok(Map.of("s", r.getStatus(), "last", r.getLast(), "from", r.getFrom(), "to", r.getTo()));
+        resp.put("last", r.getLast());
+        resp.put("from", r.getFrom());
+        resp.put("to", r.getTo());
+        return ResponseEntity.ok(resp);
     }
 
     @GetMapping("/tickers")
     public ResponseEntity<Map<String, Object>> getTickers() {
         TickersResponse r = dbMarketService.getTickers();
-        return ResponseEntity.ok(Map.of("s", r.getStatus(), "tickers", r.getTickers()));
+        java.util.Map<String, Object> resp = new java.util.HashMap<>();
+        resp.put("status", r.getStatus());
+        resp.put("tickers", r.getTickers());
+        return ResponseEntity.ok(resp);
     }
 
     @GetMapping("/symbols")
     public ResponseEntity<Map<String, Object>> getSymbols() {
         SymbolsResponse r = dbMarketService.getSymbols();
-        return ResponseEntity.ok(Map.of("s", r.getStatus(), "symbols", r.getSymbols()));
+        java.util.Map<String, Object> resp = new java.util.HashMap<>();
+        resp.put("status", r.getStatus());
+        resp.put("symbols", r.getSymbols());
+        return ResponseEntity.ok(resp);
+    }
+
+    // 과거 스냅샷: 지정 날짜의 종가/전일 종가 기반 지표를 일괄 반환
+    @GetMapping("/snapshot")
+    public ResponseEntity<Map<String, Object>> getSnapshot(
+            @RequestParam("date") String dateStr,
+            @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
+            @RequestParam(value = "size", required = false, defaultValue = "6") Integer size,
+            @RequestParam(value = "sort", required = false, defaultValue = "changePercent,desc") String sort,
+            @RequestParam(value = "symbols", required = false) String symbolsCsv
+    ) {
+        try {
+            LocalDate date = LocalDate.parse(dateStr);
+            java.util.Map<String, Object> pageResp = dbMarketService.getSnapshotPage(date, page, size, sort, symbolsCsv);
+            return ResponseEntity.ok(pageResp);
+        } catch (Exception e) {
+            java.util.Map<String, Object> resp = new java.util.HashMap<>();
+            resp.put("status", "error");
+            resp.put("message", e.getMessage());
+            resp.put("rows", java.util.List.of());
+            return ResponseEntity.ok(resp);
+        }
     }
 }
 

--- a/src/main/java/team/shdsesc/stocksimul/market/repository/ReportRepository.java
+++ b/src/main/java/team/shdsesc/stocksimul/market/repository/ReportRepository.java
@@ -22,4 +22,13 @@ public interface ReportRepository extends JpaRepository<Report, ReportId> {
             @Param("to") LocalDateTime to
     );
 
+    // 미사용: 다종목 범위 조회 메서드는 필요 시 복원
+
+    // 대량 조회: 전체 종목의 특정 기간 종가를 한 번에 조회 (stockId, date, close)
+    @Query("select r.id.stockId, r.id.date, r.close from Report r where (:from is null or r.id.date >= :from) and (:to is null or r.id.date <= :to) order by r.id.stockId asc, r.id.date asc")
+    List<Object[]> findClosesByRange(
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
+
 }

--- a/src/main/java/team/shdsesc/stocksimul/market/service/DbMarketService.java
+++ b/src/main/java/team/shdsesc/stocksimul/market/service/DbMarketService.java
@@ -12,9 +12,11 @@ import team.shdsesc.stocksimul.market.entity.Stock;
 import team.shdsesc.stocksimul.market.repository.ReportRepository;
 import team.shdsesc.stocksimul.market.repository.MarketStockRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -135,6 +137,158 @@ public class DbMarketService {
                 })
                 .collect(Collectors.toList());
         return new SymbolsResponse("ok", symbols);
+    }
+
+    /**
+     * 스냅샷 페이지(정렬/필터/페이징) 계산을 서비스에서 수행하여 컨트롤러 단순화
+     */
+    public java.util.Map<String, Object> getSnapshotPage(LocalDate date, Integer page, Integer size, String sort, String symbolsCsv) {
+        List<java.util.Map<String, Object>> rows = getSnapshotRows(date);
+
+        // sort parsing: key,direction
+        String sortKey = "changePercentValue"; // default numeric key
+        boolean desc = true;
+        if (sort != null && !sort.isBlank()) {
+            String[] parts = sort.split(",");
+            String k = parts[0].trim();
+            String d = parts.length > 1 ? parts[1].trim().toLowerCase() : "desc";
+            switch (k) {
+                case "name": sortKey = "name"; break;
+                case "price": sortKey = "priceValue"; break;
+                case "change": sortKey = "changeValue"; break;
+                case "changePercent": sortKey = "changePercentValue"; break;
+                default: break;
+            }
+            desc = !"asc".equals(d);
+        }
+
+        final String sortKeyFinal = sortKey;
+        final boolean descFinal = desc;
+        rows.sort((a, b) -> {
+            Object va = a.get(sortKeyFinal);
+            Object vb = b.get(sortKeyFinal);
+            int cmp;
+            if (va instanceof Number && vb instanceof Number) {
+                cmp = Double.compare(((Number) va).doubleValue(), ((Number) vb).doubleValue());
+            } else {
+                cmp = String.valueOf(va).compareToIgnoreCase(String.valueOf(vb));
+            }
+            return descFinal ? -cmp : cmp;
+        });
+
+        // 선택 심볼 필터
+        java.util.Set<String> pick = null;
+        if (symbolsCsv != null && !symbolsCsv.isBlank()) {
+            pick = java.util.Arrays.stream(symbolsCsv.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(java.util.stream.Collectors.toSet());
+            if (!pick.isEmpty()) {
+                final java.util.Set<String> pickFinal = pick;
+                rows = rows.stream().filter(r -> pickFinal.contains(String.valueOf(r.get("symbol")))).toList();
+            }
+        }
+
+        int total = rows.size();
+        int p = (page == null || page < 1) ? 1 : page;
+        int s = (size == null || size < 1) ? 6 : size;
+        int from = Math.min((p - 1) * s, Math.max(total - 1, 0));
+        int to = Math.min(from + s, total);
+        List<java.util.Map<String, Object>> pageRows = rows.subList(from, to);
+
+        java.util.Map<String, Object> resp = new java.util.HashMap<>();
+        resp.put("status", "ok");
+        resp.put("s", "ok");
+        resp.put("total", total);
+        resp.put("page", p);
+        resp.put("size", s);
+        resp.put("rows", pageRows);
+        return resp;
+    }
+
+    // getSnapshotRowsPage 제거됨 (미사용)
+
+    /**
+     * 지정된 날짜에 대한 모든 종목의 스냅샷(해당일 종가와 전일 종가 기반)을 계산하여 반환합니다.
+     * 반환 형식: List<Map> with keys: symbol, name, price, change, changePercent
+     */
+    public List<java.util.Map<String, Object>> getSnapshotRows(LocalDate date) {
+        if (date == null) {
+            return java.util.Collections.emptyList();
+        }
+        LocalDate prev = date.minusDays(1);
+        LocalDateTime selStart = date.atStartOfDay();
+        LocalDateTime selEnd = date.atTime(23, 59, 59);
+        LocalDateTime prevStart = prev.atStartOfDay();
+        LocalDateTime prevEnd = prev.atTime(23, 59, 59);
+        // 대량 쿼리로 (stockId, date, close) 한번에 로드
+        // 빈 결과 방지: 기간에 데이터가 없으면 최근 range를 기준으로 계산
+        List<Object[]> tuples = reportRepository.findClosesByRange(prevStart, selEnd);
+        if (tuples == null || tuples.isEmpty()) {
+            // 가장 최근 날짜 범위를 조회해 스냅샷 구성 (fallback)
+            try {
+                List<Stock> allStocks = stockRepository.findAllOrderByTicker();
+                if (allStocks.isEmpty()) return java.util.Collections.emptyList();
+                // 첫 종목 기준으로 최근 범위를 구하고 동일 범위를 사용 (간단한 폴백)
+                Optional<LocalDateTime> lastOpt = reportRepository.findLastDate(allStocks.get(0).getStockId());
+                if (lastOpt.isPresent()) {
+                    LocalDateTime last = lastOpt.get();
+                    LocalDateTime from = last.minusDays(7).withHour(0).withMinute(0).withSecond(0).withNano(0);
+                    LocalDateTime to = last.withHour(23).withMinute(59).withSecond(59).withNano(0);
+                    List<Object[]> backup = reportRepository.findClosesByRange(from, to);
+                    if (backup != null) {
+                        tuples = backup;
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+        java.util.Map<Long, double[]> closeMap = new java.util.HashMap<>();
+        if (tuples == null) tuples = java.util.Collections.emptyList();
+        for (Object[] t : tuples) {
+            Long sid = (Long) t[0];
+            LocalDateTime dt = (LocalDateTime) t[1];
+            Double close = (Double) t[2];
+            double[] arr = closeMap.computeIfAbsent(sid, k -> new double[]{Double.NaN, Double.NaN});
+            if (!dt.isAfter(prevEnd)) {
+                // 전일 종가(마지막 값)
+                arr[0] = close;
+            } else if (!dt.isBefore(selStart)) {
+                // 당일 종가(첫 값)
+                if (Double.isNaN(arr[1])) arr[1] = close;
+            }
+        }
+
+        List<Stock> all = stockRepository.findAllOrderByTicker();
+        List<java.util.Map<String, Object>> rows = new ArrayList<>();
+        for (Stock s : all) {
+            Long stockId = s.getStockId();
+            if (stockId == null) continue;
+            double[] arr = closeMap.get(stockId);
+            if (arr == null) continue;
+            double prevClose = arr[0];
+            double selClose = arr[1];
+            if (Double.isNaN(prevClose) || Double.isNaN(selClose)) continue;
+
+            rows.add(buildSnapshotRow(s, prevClose, selClose));
+        }
+        return rows;
+    }
+
+    private static java.util.Map<String, Object> buildSnapshotRow(Stock stock, double prevClose, double selClose) {
+        double chg = selClose - prevClose;
+        double pct = prevClose != 0.0 ? (chg / prevClose) * 100.0 : 0.0;
+        java.util.Map<String, Object> row = new HashMap<>();
+        row.put("symbol", stock.getTicker());
+        row.put("name", stock.getName());
+        // numeric values for server-side sort
+        row.put("priceValue", selClose);
+        row.put("changeValue", chg);
+        row.put("changePercentValue", pct);
+        // formatted strings for display
+        row.put("price", String.format("$%.2f", selClose));
+        row.put("change", String.format("%s%.2f", chg >= 0 ? "+" : "", chg));
+        row.put("changePercent", String.format("%s%.2f%%", pct >= 0 ? "+" : "", pct));
+        return row;
     }
 
     private static String resolveTicker(String tickerParam, String symbolParam) {

--- a/src/main/java/team/shdsesc/stocksimul/user/UserService.java
+++ b/src/main/java/team/shdsesc/stocksimul/user/UserService.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
-//    private final UsersLikesRepository usersLikesRepository;
+    private final UsersLikesRepository usersLikesRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisDAO redisDAO;
 

--- a/src/main/java/team/shdsesc/stocksimul/user/UsersLikesController.java
+++ b/src/main/java/team/shdsesc/stocksimul/user/UsersLikesController.java
@@ -1,0 +1,175 @@
+package team.shdsesc.stocksimul.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.shdsesc.stocksimul.userprofile.UserProfileRepository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/user/likes")
+@RequiredArgsConstructor
+@Log4j2
+public class UsersLikesController {
+    
+    private final UsersLikesService usersLikesService;
+    private final UserProfileRepository userProfileRepository;
+    
+    // 관심종목 추가
+    @PostMapping("/add")
+    public ResponseEntity<Map<String, Object>> addToWatchlist(
+            @RequestParam("profileId") Long profileId,
+            @RequestParam("stockId") String ticker) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            boolean success = usersLikesService.addToWatchlist(profileId, ticker);
+            
+            if (success) {
+                response.put("status", "success");
+                response.put("message", "관심종목에 추가되었습니다");
+            } else {
+                response.put("status", "error");
+                response.put("message", "이미 관심종목에 있거나 추가에 실패했습니다");
+            }
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (Exception e) {
+            log.error("관심종목 추가 API 오류: {}", e.getMessage());
+            response.put("status", "error");
+            response.put("message", "관심종목 추가 중 오류가 발생했습니다");
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+    
+    // 관심종목 제거
+    @DeleteMapping("/remove")
+    public ResponseEntity<Map<String, Object>> removeFromWatchlist(
+            @RequestParam("profileId") Long profileId,
+            @RequestParam("stockId") String ticker) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            boolean success = usersLikesService.removeFromWatchlist(profileId, ticker);
+            
+            if (success) {
+                response.put("status", "success");
+                response.put("message", "관심종목에서 제거되었습니다");
+            } else {
+                response.put("status", "error");
+                response.put("message", "관심종목 제거에 실패했습니다");
+            }
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (Exception e) {
+            log.error("관심종목 제거 API 오류: {}", e.getMessage());
+            response.put("status", "error");
+            response.put("message", "관심종목 제거 중 오류가 발생했습니다");
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+    
+    // 관심종목 목록 조회
+    @GetMapping("/list")
+    public ResponseEntity<Map<String, Object>> getWatchlist(
+            @RequestParam("profileId") Long profileId) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            // 프로필 존재 확인
+            if (!userProfileRepository.existsById(profileId)) {
+                response.put("status", "error");
+                response.put("message", "프로필을 찾을 수 없습니다");
+                return ResponseEntity.badRequest().body(response);
+            }
+            
+            List<String> watchlist = usersLikesService.getWatchlist(profileId);
+            
+            response.put("status", "success");
+            response.put("watchlist", watchlist);
+            response.put("count", watchlist.size());
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (Exception e) {
+            log.error("관심종목 목록 조회 API 오류: {}", e.getMessage());
+            response.put("status", "error");
+            response.put("message", "관심종목 목록 조회 중 오류가 발생했습니다");
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+    
+    // 관심종목 여부 확인
+    @GetMapping("/check")
+    public ResponseEntity<Map<String, Object>> checkWatchlist(
+            @RequestParam("profileId") Long profileId,
+            @RequestParam("stockId") String ticker) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            boolean isInWatchlist = usersLikesService.isInWatchlist(profileId, ticker);
+            
+            response.put("status", "success");
+            response.put("isInWatchlist", isInWatchlist);
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (Exception e) {
+            log.error("관심종목 확인 API 오류: {}", e.getMessage());
+            response.put("status", "error");
+            response.put("message", "관심종목 확인 중 오류가 발생했습니다");
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+    
+    // 관심종목 토글 (추가/제거)
+    @PostMapping("/toggle")
+    public ResponseEntity<Map<String, Object>> toggleWatchlist(
+            @RequestParam("profileId") Long profileId,
+            @RequestParam("stockId") String ticker) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            boolean isInWatchlist = usersLikesService.isInWatchlist(profileId, ticker);
+            boolean success;
+            String action;
+            
+            if (isInWatchlist) {
+                success = usersLikesService.removeFromWatchlist(profileId, ticker);
+                action = "제거";
+            } else {
+                success = usersLikesService.addToWatchlist(profileId, ticker);
+                action = "추가";
+            }
+            
+            if (success) {
+                response.put("status", "success");
+                response.put("message", "관심종목에서 " + action + "되었습니다");
+                response.put("isInWatchlist", !isInWatchlist);
+            } else {
+                response.put("status", "error");
+                response.put("message", "관심종목 " + action + "에 실패했습니다");
+            }
+            
+            return ResponseEntity.ok(response);
+            
+        } catch (Exception e) {
+            log.error("관심종목 토글 API 오류: {}", e.getMessage());
+            response.put("status", "error");
+            response.put("message", "관심종목 토글 중 오류가 발생했습니다");
+            return ResponseEntity.internalServerError().body(response);
+        }
+    }
+}
+

--- a/src/main/java/team/shdsesc/stocksimul/user/UsersLikesEntity.java
+++ b/src/main/java/team/shdsesc/stocksimul/user/UsersLikesEntity.java
@@ -1,0 +1,27 @@
+package team.shdsesc.stocksimul.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+import team.shdsesc.stocksimul.userprofile.UserProfileEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "userslikes")
+public class UsersLikesEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "users_likes_id")
+    private Long usersLikesId;
+
+    @JoinColumn(name = "users_profile_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private UserProfileEntity userProfile;
+
+    @Column(name = "stock_id", nullable = false)
+    private Long stockId;
+}
+

--- a/src/main/java/team/shdsesc/stocksimul/user/UsersLikesRepository.java
+++ b/src/main/java/team/shdsesc/stocksimul/user/UsersLikesRepository.java
@@ -1,0 +1,32 @@
+package team.shdsesc.stocksimul.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UsersLikesRepository extends JpaRepository<UsersLikesEntity, Long> {
+    
+    // 특정 프로필의 관심종목 목록 조회
+    @Query("SELECT ul FROM UsersLikesEntity ul WHERE ul.userProfile.usersProfileId = :profileId")
+    List<UsersLikesEntity> findByUserProfileId(@Param("profileId") Long profileId);
+    
+    // 특정 프로필의 특정 주식이 관심종목에 있는지 확인
+    @Query("SELECT ul FROM UsersLikesEntity ul WHERE ul.userProfile.usersProfileId = :profileId AND ul.stockId = :stockId")
+    Optional<UsersLikesEntity> findByUserProfileIdAndStockId(@Param("profileId") Long profileId, @Param("stockId") Long stockId);
+    
+    // 특정 프로필의 관심종목 삭제
+    @Modifying
+    @Query("DELETE FROM UsersLikesEntity ul WHERE ul.userProfile.usersProfileId = :profileId AND ul.stockId = :stockId")
+    int deleteByUserProfileIdAndStockId(@Param("profileId") Long profileId, @Param("stockId") Long stockId);
+    
+    // 특정 프로필의 모든 관심종목 삭제
+    @Modifying
+    @Query("DELETE FROM UsersLikesEntity ul WHERE ul.userProfile.usersProfileId = :profileId")
+    int deleteByUserProfileId(@Param("profileId") Long profileId);
+}

--- a/src/main/java/team/shdsesc/stocksimul/user/UsersLikesService.java
+++ b/src/main/java/team/shdsesc/stocksimul/user/UsersLikesService.java
@@ -1,0 +1,140 @@
+package team.shdsesc.stocksimul.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.shdsesc.stocksimul.userprofile.UserProfileEntity;
+import team.shdsesc.stocksimul.market.entity.Stock;
+import team.shdsesc.stocksimul.market.repository.MarketStockRepository;
+import team.shdsesc.stocksimul.userprofile.UserProfileRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class UsersLikesService {
+    
+    private final UsersLikesRepository usersLikesRepository;
+    private final UserProfileRepository userProfileRepository;
+    private final MarketStockRepository marketStockRepository;
+    
+    // 관심종목 추가
+    @Transactional
+    public boolean addToWatchlist(Long profileId, String ticker) {
+        try {
+            // 프로필 존재 확인
+            if (!userProfileRepository.existsById(profileId)) {
+                log.warn("프로필이 존재하지 않습니다: {}", profileId);
+                return false;
+            }
+            
+            // 티커로 stock_id 조회
+            Optional<Stock> stockOpt = marketStockRepository.findByTicker(ticker);
+            if (stockOpt.isEmpty()) {
+                log.warn("티커를 찾을 수 없습니다: {}", ticker);
+                return false;
+            }
+            Long stockId = stockOpt.get().getStockId();
+
+            // 이미 관심종목에 있는지 확인
+            Optional<UsersLikesEntity> existing = usersLikesRepository
+                .findByUserProfileIdAndStockId(profileId, stockId);
+            
+            if (existing.isPresent()) {
+                log.info("이미 관심종목에 있습니다: profileId={}, stockId={}", profileId, stockId);
+                return false;
+            }
+            
+            // 관심종목 추가
+            UserProfileEntity userProfile = userProfileRepository.findById(profileId)
+                .orElseThrow(() -> new RuntimeException("프로필을 찾을 수 없습니다"));
+            
+            UsersLikesEntity usersLikes = UsersLikesEntity.builder()
+                .userProfile(userProfile)
+                .stockId(stockId)
+                .build();
+            
+            usersLikesRepository.save(usersLikes);
+            log.info("관심종목 추가 성공: profileId={}, stockId={}", profileId, stockId);
+            return true;
+            
+        } catch (Exception e) {
+            log.error("관심종목 추가 실패: profileId={}, ticker={}, error={}", profileId, ticker, e.getMessage());
+            return false;
+        }
+    }
+    
+    // 관심종목 제거
+    @Transactional
+    public boolean removeFromWatchlist(Long profileId, String ticker) {
+        try {
+            Optional<Stock> stockOpt = marketStockRepository.findByTicker(ticker);
+            if (stockOpt.isEmpty()) {
+                log.warn("티커를 찾을 수 없습니다: {}", ticker);
+                return false;
+            }
+            Long stockId = stockOpt.get().getStockId();
+
+            int deletedCount = usersLikesRepository.deleteByUserProfileIdAndStockId(profileId, stockId);
+            if (deletedCount > 0) {
+                log.info("관심종목 제거 성공: profileId={}, stockId={}", profileId, stockId);
+                return true;
+            } else {
+                log.warn("관심종목이 존재하지 않습니다: profileId={}, stockId={}", profileId, stockId);
+                return false;
+            }
+        } catch (Exception e) {
+            log.error("관심종목 제거 실패: profileId={}, ticker={}, error={}", profileId, ticker, e.getMessage());
+            return false;
+        }
+    }
+    
+    // 관심종목 목록 조회
+    public List<String> getWatchlist(Long profileId) {
+        try {
+            List<UsersLikesEntity> likes = usersLikesRepository.findByUserProfileId(profileId);
+            // stock_id -> ticker 변환
+            List<Long> stockIds = likes.stream().map(UsersLikesEntity::getStockId).toList();
+            if (stockIds.isEmpty()) return List.of();
+            // 간단히 one-by-one 조회 (필요시 batch 최적화 가능)
+            return stockIds.stream()
+                    .map(id -> marketStockRepository.findById(id).map(Stock::getTicker).orElse(null))
+                    .filter(t -> t != null)
+                    .toList();
+        } catch (Exception e) {
+            log.error("관심종목 목록 조회 실패: profileId={}, error={}", profileId, e.getMessage());
+            return List.of();
+        }
+    }
+    
+    // 관심종목 여부 확인
+    public boolean isInWatchlist(Long profileId, String ticker) {
+        try {
+            Optional<Stock> stockOpt = marketStockRepository.findByTicker(ticker);
+            if (stockOpt.isEmpty()) {
+                return false;
+            }
+            Long stockId = stockOpt.get().getStockId();
+            return usersLikesRepository.findByUserProfileIdAndStockId(profileId, stockId).isPresent();
+        } catch (Exception e) {
+            log.error("관심종목 확인 실패: profileId={}, ticker={}, error={}", profileId, ticker, e.getMessage());
+            return false;
+        }
+    }
+    
+    // 프로필의 모든 관심종목 삭제
+    @Transactional
+    public boolean clearWatchlist(Long profileId) {
+        try {
+            int deletedCount = usersLikesRepository.deleteByUserProfileId(profileId);
+            log.info("관심종목 전체 삭제 성공: profileId={}, deletedCount={}", profileId, deletedCount);
+            return true;
+        } catch (Exception e) {
+            log.error("관심종목 전체 삭제 실패: profileId={}, error={}", profileId, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileDTO.java
@@ -22,4 +22,9 @@ public class UserProfileDTO {
     private String name ="";
     private Integer state;
     private LocalDateTime processDate;
+    // Timeline details for FE routing and chart mode
+    private Long timelineId;
+    private Integer timelineType;
+    private LocalDateTime timelineFrom;
+    private LocalDateTime timelineTo;
 }

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileService.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import team.shdsesc.stocksimul.user.UserEntity;
 import team.shdsesc.stocksimul.user.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -72,6 +71,10 @@ public class UserProfileService {
                 .nickname(entity.getNickname())
                 .name(entity.getTimeLine().getName())
                 .processDate(entity.getProcessDate())
+                .timelineId(entity.getTimeLine().getTimelineId())
+                .timelineType(entity.getTimeLine().getType())
+                .timelineFrom(entity.getTimeLine().getFrom())
+                .timelineTo(entity.getTimeLine().getTo())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 
1. 관심 종목 기능
2. /stocks 페이지에서 등락률 기준으로 종목들을 확인할 수 있고, /home 에서는 실시간 급상승 top3 을 확인할 수 있음
3. 실시간 타임라인은 계속 갱신되는 redis에서 데이터를, 과거 타임라인의 데이터는 DB 에서 가져오도록 구분했습니다.

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 