### PR TITLE
매수/매도 등락률 반영 오류 수정 

### DIFF
--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsService.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsService.java
@@ -20,34 +20,33 @@ public class HoldingsService {
     private static final String STOCK_IMG_EXTENSION = ".png";
 
     public HoldingsDTO toHoldingsResponseDTOS(HoldingsEntity holdingsEntity, LocalDateTime date) {
+        // 현재 주가 (1주당)
+        Double currentPrice = reportRepository.findClosesPrice(date, holdingsEntity.getStock().getStockId());
 
-        // 금일 주식 가격 (1주)
-        Double avgPrice = reportRepository.findClosesPrice(date, holdingsEntity.getStock().getStockId());
+        // 구매시 총 투자금액
+        Double totalInvested = holdingsEntity.getTotalPrice();
 
-        // 가저온 실 구매가
-        Double price = holdingsEntity.getTotalPrice();
-
-        // 구매량
+        // 보유 수량
         Long quantity = holdingsEntity.getQuantity();
 
-        // 주당 총 주가 (금일 기준 반영)
-        Double totalPrice = formatUtil.changePriceFormatter(quantity * avgPrice);
+        // 현재 총 평가금액
+        Double currentTotalValue = formatUtil.changePriceFormatter(quantity * currentPrice);
 
-        // 등락률
-        double changeRate = formatUtil.changePriceFormatter(totalPrice / price - 1);
-        // 등락가
-        double changeAmount = formatUtil.changePriceFormatter(totalPrice - price);
+        // 평가손익 (현재가치 - 투자금액)
+        Double profitLoss = formatUtil.changePriceFormatter(currentTotalValue - totalInvested);
+
+        // 수익률 (%) = (평가손익 / 투자금액) * 100
+        Double returnRate = formatUtil.changePriceFormatter((profitLoss / totalInvested) * 100);
 
         return HoldingsDTO.builder()
                 .ticker(holdingsEntity.getStock().getTicker())
                 .name(holdingsEntity.getStock().getName())
-                .price(totalPrice)
+                .price(currentTotalValue)  // 현재 총 평가금액
                 .quantity(holdingsEntity.getQuantity())
-                .change(changeRate)
-                .changeAmount(changeAmount)
+                .change(returnRate)       // 수익률 (%)
+                .changeAmount(profitLoss) // 평가손익 ($)
                 .logo(STOCK_IMG_LINK + holdingsEntity.getStock().getTicker() + STOCK_IMG_EXTENSION)
                 .build();
-
     }
 
     HoldingsResponseDTO getHoldingsList(Long usersProfileId, String currentDate) {

--- a/src/main/java/team/shdsesc/stocksimul/order/OfferService.java
+++ b/src/main/java/team/shdsesc/stocksimul/order/OfferService.java
@@ -1,6 +1,7 @@
 package team.shdsesc.stocksimul.order;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import team.shdsesc.stocksimul.holdings.HoldingsEntity;
 import team.shdsesc.stocksimul.holdings.HoldingsRepository;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class OfferService {
     private final OfferRepository offerRepository;
     private final UserProfileRepository userProfileRepository;
@@ -59,13 +61,14 @@ public class OfferService {
                 ? price + tPrice // 기존 총합 금액 + 토탈 금액
                 : price - tPrice;// 기촌 총합 금액 - 토탈 금액
 
-        double remainCashBalance = userProfile.getCashBalance() - totalPrice;
+        double remainCashBalance = dto.type == OfferType.BUY ?
+                userProfile.getCashBalance() - tPrice : userProfile.getCashBalance() + tPrice;
+
+        log.info("매매/매도" + dto.type + totalPrice + " " + userProfile.getCashBalance() + " " + price + " " + tPrice);
 
         // 수량이 0보다 작아지면 실패
         if (quantity < 0) {
             throw new RuntimeException("quantity less than 0");
-        } else if (totalPrice < 0) {
-            throw new RuntimeException("totalPrice less than 0");
         } else if (remainCashBalance < 0) {
             throw new RuntimeException("remainCashBalance less than 0");
         }

--- a/src/main/java/team/shdsesc/stocksimul/util/FormatUtil.java
+++ b/src/main/java/team/shdsesc/stocksimul/util/FormatUtil.java
@@ -10,12 +10,16 @@ import java.time.format.DateTimeFormatter;
 
 @Component
 public class FormatUtil {
-    public Double changePriceFormatter(Double price){
-        BigDecimal value = BigDecimal.valueOf(price).setScale(3, RoundingMode.FLOOR);
-        return value.doubleValue();
+    public Double changePriceFormatter(Double price) {
+        try {
+            BigDecimal value = BigDecimal.valueOf(price).setScale(3, RoundingMode.FLOOR);
+            return value.doubleValue();
+        } catch (Exception e) {
+            return 0.0;
+        }
     }
 
-    public LocalDateTime localDateTimeFormatter(String curDate){
+    public LocalDateTime localDateTimeFormatter(String curDate) {
         LocalDate date = LocalDate.parse(curDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         return date.atStartOfDay();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43

## 📝작업 내용

- [ ] 매도/매수 시 금액 반영
    - [x] 보유 수량 
    - [x] 총 잔고
    - [x] 투자
    - [x] 현금
    - [x] 보유 주식 등락율
    - [x] 보유 주식 등락가
    - [x] 전체 주식 등락율
    - [x] 전체 주식 등락가
- [x] 날짜 누르면 달력, 달력 클릭 시 원하는 날짜 이동 로직 추가
- [ ] 턴 종료 시 포트폴리오 화면 반영

### 스크린샷 (선택)
<img width="920" height="82" alt="image" src="https://github.com/user-attachments/assets/523c887b-577e-43e2-9e65-62f441f61bc4" />


## 💬리뷰 요구사항(선택)

> 