### PR TITLE
Feat: 캘린더, 턴 종료, 포트폴리오 백엔드 로직 추가

### DIFF
--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsController.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsController.java
@@ -7,8 +7,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/holdings")
 @RequiredArgsConstructor
@@ -16,7 +14,7 @@ public class HoldingsController {
     private final HoldingsService holdingsService;
 
     @GetMapping("/stocks/{usersProfileId}/{setCurrentDate}")
-    ResponseEntity<HoldingsResponseDTO> getHoldingsStockList(@PathVariable Long usersProfileId, @PathVariable String setCurrentDate){
+    ResponseEntity<HoldingsResponseDTO> getHoldingsStockList(@PathVariable Long usersProfileId, @PathVariable String setCurrentDate) {
         return ResponseEntity
                 .ok()
                 .body(holdingsService.getHoldingsList(usersProfileId, setCurrentDate));

--- a/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsService.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/HoldingsService.java
@@ -19,6 +19,17 @@ public class HoldingsService {
     private static final String STOCK_IMG_LINK = "https://financialmodelingprep.com/image-stock/";
     private static final String STOCK_IMG_EXTENSION = ".png";
 
+    public PortfolioResponseDTO getPortfolio(Long usersProfileId, String currentDate){
+        // 보유 주식 리스트
+        HoldingsResponseDTO holdingsList = getHoldingsList(usersProfileId, currentDate);
+        // 보유 주식 변환 리스트
+        List<HoldingsDTO> holdingsDTOList = holdingsList.getHoldingsResponseDTOS();
+
+        return PortfolioResponseDTO.builder()
+                .holdingsDTOList(holdingsDTOList)
+                .build();
+    }
+
     public HoldingsDTO toHoldingsResponseDTOS(HoldingsEntity holdingsEntity, LocalDateTime date) {
         // 현재 주가 (1주당)
         Double currentPrice = reportRepository.findClosesPrice(date, holdingsEntity.getStock().getStockId());
@@ -56,7 +67,7 @@ public class HoldingsService {
                 .map(entity -> toHoldingsResponseDTOS(entity, formatUtil.localDateTimeFormatter(currentDate)))
                 .toList();
         double totalCurrentPrice = holdingsDTOList.stream()
-                .mapToDouble(HoldingsDTO::getPrice) // 필드를 꺼낸다
+                .mapToDouble(HoldingsDTO::getPrice)
                 .sum();
 
         return HoldingsResponseDTO.builder()

--- a/src/main/java/team/shdsesc/stocksimul/holdings/PortfolioResponseDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/holdings/PortfolioResponseDTO.java
@@ -1,0 +1,16 @@
+package team.shdsesc.stocksimul.holdings;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortfolioResponseDTO {
+    private List<HoldingsDTO> holdingsDTOList;
+}

--- a/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileController.java
+++ b/src/main/java/team/shdsesc/stocksimul/userprofile/UserProfileController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.shdsesc.stocksimul.holdings.HoldingsService;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ import java.util.List;
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
+    private final HoldingsService holdingsService;
 
     @GetMapping("/timelines")
     @Operation(summary = "타임라인 목록 조회", description = "타임라인 목록을 조회합니다.")
@@ -65,8 +67,7 @@ public class UserProfileController {
     public ResponseEntity<?> updateProcessDate(@RequestBody UpdateUserProfileProcessDateDTO userProfileProcessDateDTO) {
         userProfileService.updateProcessDate(userProfileProcessDateDTO.getUserProfileId(), userProfileProcessDateDTO.getProcessDate());
         return ResponseEntity
-                .ok()
-                .build();
+                .ok(holdingsService.getPortfolio(userProfileProcessDateDTO.getUserProfileId(), userProfileProcessDateDTO.getProcessDate()));
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43

## 📝작업 내용

> 캘린더 선택 시 이동 및 포트폴리오 지수 반영
> 턴 종료 시 다음 날 이동 및 일 별 포트폴리오 요약

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 