### PR TITLE
에이전트 과거 데이터 미리보기 수정

### DIFF
--- a/src/main/java/team/shdsesc/stocksimul/agent/AgentService.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/AgentService.java
@@ -83,7 +83,7 @@ public class AgentService {
 
     /**
      * historical/predictions 시계열을 표준화하여 DTO에 채워 넣습니다.
-     * - historical: base_date - 30일 ~ pred_end_date까지의 종가를 UTC epoch 초로 정렬
+     * - historical: base_date - 50일 ~ pred_end_date까지의 종가를 UTC epoch 초로 정렬
      * - predictions: base_date 다음날부터 pred_end_date까지, base_date 직전 실제값 기준으로 리베이스
      */
     private PredictResponseDTO enrichChartSeries(PredictResponseDTO resp) {
@@ -100,13 +100,13 @@ public class AgentService {
         }
         resp.setPredEndDate(predEnd);
 
-        // 2) 과거 구간 조회: base_date - 30d ~ pred_end_date(or base_date)
+        // 2) 과거 구간 조회: base_date - 50d ~ pred_end_date(or base_date)
         String baseDate = resp.getBaseDate();
         if (baseDate == null || baseDate.isBlank()) return resp;
         try {
             java.time.LocalDate base = java.time.LocalDate.parse(baseDate);
             java.time.LocalDate end = predEnd != null ? java.time.LocalDate.parse(predEnd) : base;
-            long fromEpoch = base.minusDays(30).atStartOfDay().toEpochSecond(java.time.ZoneOffset.UTC);
+            long fromEpoch = base.minusDays(50).atStartOfDay().toEpochSecond(java.time.ZoneOffset.UTC);
             long toEpoch = end.atTime(23, 59, 59).toEpochSecond(java.time.ZoneOffset.UTC);
             long baseTs = base.atStartOfDay().toEpochSecond(java.time.ZoneOffset.UTC);
             long baseEndTs = base.atTime(23, 59, 59).toEpochSecond(java.time.ZoneOffset.UTC);

--- a/src/main/java/team/shdsesc/stocksimul/agent/AgentService.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/AgentService.java
@@ -35,8 +35,8 @@ public class AgentService {
                 .bodyToMono(PredictResponseDTO.class)
                 // FastAPI가 return_predictions를 비워 보낸 경우 보강
                 .map(this::ensureReturnPredictions)
-                // 프론트가 바로 사용할 수 있도록 시계열 정규화
-                .map(this::enrichChartSeries)
+                // 프론트가 바로 사용할 수 있도록 시계열 정규화 (process_date 전달)
+                .map(response -> enrichChartSeries(response, requestDTO.getProcessDate()))
                 .timeout(Duration.ofMinutes(5))  // Mono 레벨 타임아웃도 5분으로 설정
                 .onErrorResume(throwable -> {
 //                    return Mono.just(new PredictResponseDTO());
@@ -101,8 +101,9 @@ public class AgentService {
      * historical/predictions 시계열을 표준화하여 DTO에 채워 넣습니다.
      * - historical: base_date - 50일 ~ pred_end_date까지의 종가를 UTC epoch 초로 정렬
      * - predictions: base_date 다음날부터 pred_end_date까지, base_date 직전 실제값 기준으로 리베이스
+     * - process_date가 있으면 해당 날짜 이후의 historical 데이터는 필터링하여 스포일러 방지
      */
-    private PredictResponseDTO enrichChartSeries(PredictResponseDTO resp) {
+    private PredictResponseDTO enrichChartSeries(PredictResponseDTO resp, java.time.LocalDate processDate) {
         if (resp == null) return null;
 
         // 1) pred_end_date 계산
@@ -143,6 +144,15 @@ public class AgentService {
                 }
             }
             historical.sort(java.util.Comparator.comparingLong(ChartSeriesPoint::getTime));
+            
+            // process_date가 있으면 해당 날짜 이후의 historical 데이터 필터링
+            if (processDate != null) {
+                long processTimestamp = processDate.atTime(23, 59, 59).toEpochSecond(java.time.ZoneOffset.UTC);
+                historical = historical.stream()
+                        .filter(point -> point.getTime() <= processTimestamp)
+                        .collect(java.util.stream.Collectors.toList());
+            }
+            
             resp.setHistorical(historical);
 
             // 3) predictions 시리즈 생성 (리베이스)
@@ -200,6 +210,13 @@ public class AgentService {
         } catch (Exception e) {
             return resp; // 파싱 실패 시 원본 유지
         }
+    }
+
+    /**
+     * 기존 호환성을 위한 오버로드 메서드 (process_date 없이)
+     */
+    private PredictResponseDTO enrichChartSeries(PredictResponseDTO resp) {
+        return enrichChartSeries(resp, null);
     }
 
 }

--- a/src/main/java/team/shdsesc/stocksimul/agent/PredictRequestDTO.java
+++ b/src/main/java/team/shdsesc/stocksimul/agent/PredictRequestDTO.java
@@ -19,6 +19,10 @@ public class PredictRequestDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     LocalDate baseDate;
 
+    @JsonProperty("process_date")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    LocalDate processDate;
+
     int trainDays;
 
     int predictSteps;

--- a/src/main/java/team/shdsesc/stocksimul/market/controller/DbCandleController.java
+++ b/src/main/java/team/shdsesc/stocksimul/market/controller/DbCandleController.java
@@ -91,12 +91,13 @@ public class DbCandleController {
             @RequestParam(value = "page", required = false, defaultValue = "1") Integer page,
             @RequestParam(value = "size", required = false, defaultValue = "6") Integer size,
             @RequestParam(value = "sort", required = false, defaultValue = "changePercent,desc") String sort,
-            @RequestParam(value = "symbols", required = false) String symbolsCsv
+            @RequestParam(value = "symbols", required = false) String symbolsCsv,
+            @RequestParam(value = "filterLowPrice", required = false, defaultValue = "false") Boolean filterLowPrice
     ) {
         try {
             LocalDate date = LocalDate.parse(dateStr);
             // 휴장일 자동 스킵이 포함된 응답 사용 (기본 30일 범위)
-            java.util.Map<String, Object> pageResp = dbMarketService.getSnapshotPageWithSkip(date, page, size, sort, symbolsCsv, 30);
+            java.util.Map<String, Object> pageResp = dbMarketService.getSnapshotPageWithSkip(date, page, size, sort, symbolsCsv, 30, filterLowPrice);
             return ResponseEntity.ok(pageResp);
         } catch (Exception e) {
             java.util.Map<String, Object> resp = new java.util.HashMap<>();

--- a/src/main/java/team/shdsesc/stocksimul/market/service/DbMarketService.java
+++ b/src/main/java/team/shdsesc/stocksimul/market/service/DbMarketService.java
@@ -227,7 +227,7 @@ public class DbMarketService {
      * 요청된 날짜에 데이터가 없으면 앞으로 하루씩 이동하며 데이터가 있는 첫 날짜를 effectiveDate로 사용.
      * 최대 maxForwardDays까지만 탐색.
      */
-    public java.util.Map<String, Object> getSnapshotPageWithSkip(LocalDate requested, Integer page, Integer size, String sort, String symbolsCsv, int maxForwardDays) {
+    public java.util.Map<String, Object> getSnapshotPageWithSkip(LocalDate requested, Integer page, Integer size, String sort, String symbolsCsv, int maxForwardDays, Boolean filterLowPrice) {
         LocalDate effective = requested;
         int skipped = 0;
         List<java.util.Map<String, Object>> rows = getSnapshotRows(effective);
@@ -258,20 +258,23 @@ public class DbMarketService {
         if (rows == null) rows = new java.util.ArrayList<>();
         final String sortKeyFinal = sortKey;
         final boolean descFinal = desc;
-        // 최소가 필터: $1 미만 종목 제외
-        rows = rows.stream()
-                .filter(r -> {
-                    Object pv = r.get("priceValue");
-                    if (pv instanceof Number) {
-                        return ((Number) pv).doubleValue() >= 1.0;
-                    }
-                    try {
-                        return Double.parseDouble(String.valueOf(pv)) >= 1.0;
-                    } catch (Exception e) {
-                        return false;
-                    }
-                })
-                .collect(java.util.stream.Collectors.toList());
+        
+        // 조건부 최소가 필터: filterLowPrice가 true일 때만 $1 미만 종목 제외
+        if (filterLowPrice != null && filterLowPrice) {
+            rows = rows.stream()
+                    .filter(r -> {
+                        Object pv = r.get("priceValue");
+                        if (pv instanceof Number) {
+                            return ((Number) pv).doubleValue() >= 1.0;
+                        }
+                        try {
+                            return Double.parseDouble(String.valueOf(pv)) >= 1.0;
+                        } catch (Exception e) {
+                            return false;
+                        }
+                    })
+                    .collect(java.util.stream.Collectors.toList());
+        }
 
         rows.sort((a, b) -> {
             Object va = a.get(sortKeyFinal);
@@ -444,6 +447,13 @@ public class DbMarketService {
 
     private static Double nullSafeDouble(Long v) {
         return v == null ? 0.0 : v.doubleValue();
+    }
+
+    /**
+     * 기존 호환성을 위한 오버로드 메서드 (filterLowPrice 없이)
+     */
+    public java.util.Map<String, Object> getSnapshotPageWithSkip(LocalDate requested, Integer page, Integer size, String sort, String symbolsCsv, int maxForwardDays) {
+        return getSnapshotPageWithSkip(requested, page, size, sort, symbolsCsv, maxForwardDays, false);
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 에이전트 기능에서 AI 예측 차트와 비교하기 위해 과거 실제 데이터 차트를 넣었는데 process_date 이후의 데이터까지 보이던 오류를 수정했습니다.

### 스크린샷 (선택)

<img width="289" height="250" alt="image" src="https://github.com/user-attachments/assets/dcfe1f55-c663-41b6-86f5-015c9afd4336" />

## 💬리뷰 요구사항(선택)

> 